### PR TITLE
Replace Nginx with Traefik for improved local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,30 @@
 version: '3.8'
 
 services:
+  # Traefik - Reverse Proxy & Load Balancer
+  traefik:
+    image: traefik:v2.9
+    command:
+      - "--api.insecure=true"  # Enable the dashboard (in production, set to false)
+      - "--providers.docker=true"  # Enable Docker as the provider
+      - "--providers.docker.exposedbydefault=false"  # Don't expose containers by default
+      - "--entrypoints.web.address=:80"  # Define an entrypoint for HTTP
+    ports:
+      - "80:80"  # HTTP
+      - "8080:8080"  # Dashboard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro  # Mount the Docker socket
+    networks:
+      - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.traefik.rule=Host(`traefik.fb-analyzer.localhost`)"
+      - "traefik.http.routers.traefik.service=api@internal"
+
   # API Gateway
   fb-analyzer-api-gateway:
     build:
       context: ./services/fb-analyzer-api-gateway
-    ports:
-      - "8000:8000"
     depends_on:
       - mysql
       - redis
@@ -15,6 +33,10 @@ services:
       - REDIS_URL=redis://redis:6379
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.api-gateway.rule=Host(`api.fb-analyzer.localhost`)"
+      - "traefik.http.services.api-gateway.loadbalancer.server.port=8000"
 
   # Auth Service
   fb-analyzer-auth-service:
@@ -28,11 +50,15 @@ services:
       - REDIS_URL=redis://redis:6379
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.auth-service.rule=Host(`auth.fb-analyzer.localhost`)"
+      - "traefik.http.services.auth-service.loadbalancer.server.port=8000"
 
-  # Post Fetcher Service
-  fb-analyzer-post-fetcher:
+  # Event Fetcher Service (renamed from Post Fetcher)
+  fb-analyzer-event-fetcher:
     build:
-      context: ./services/fb-analyzer-post-fetcher
+      context: ./services/fb-analyzer-post-fetcher  # Keep the directory name for now
     depends_on:
       - mysql
       - redis
@@ -42,11 +68,15 @@ services:
       - FACEBOOK_API_KEY=${FACEBOOK_API_KEY}
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.event-fetcher.rule=Host(`event-fetcher.fb-analyzer.localhost`)"
+      - "traefik.http.services.event-fetcher.loadbalancer.server.port=8000"
 
-  # Post Analyzer Service
-  fb-analyzer-post-analyzer:
+  # Event Analyzer Service (renamed from Post Analyzer)
+  fb-analyzer-event-analyzer:
     build:
-      context: ./services/fb-analyzer-post-analyzer
+      context: ./services/fb-analyzer-post-analyzer  # Keep the directory name for now
     depends_on:
       - mysql
       - redis
@@ -55,6 +85,10 @@ services:
       - REDIS_URL=redis://redis:6379
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.event-analyzer.rule=Host(`event-analyzer.fb-analyzer.localhost`)"
+      - "traefik.http.services.event-analyzer.loadbalancer.server.port=8000"
 
   # Notification Service
   fb-analyzer-notification-service:
@@ -66,8 +100,12 @@ services:
       - REDIS_URL=redis://redis:6379
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.notification-service.rule=Host(`notifications.fb-analyzer.localhost`)"
+      - "traefik.http.services.notification-service.loadbalancer.server.port=8000"
 
-  # Data Processor (Golang Workers)
+  # Data Processor
   fb-analyzer-data-processor:
     build:
       context: ./services/fb-analyzer-data-processor
@@ -79,21 +117,25 @@ services:
       - REDIS_URL=redis://redis:6379
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.data-processor.rule=Host(`data-processor.fb-analyzer.localhost`)"
+      - "traefik.http.services.data-processor.loadbalancer.server.port=8000"
 
   # Frontend
   fb-analyzer-frontend:
     build:
       context: ./services/fb-analyzer-frontend
-    ports:
-      - "3000:80"
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.frontend.rule=Host(`fb-analyzer.localhost`)"
+      - "traefik.http.services.frontend.loadbalancer.server.port=80"
 
   # MySQL Database
   mysql:
     image: mysql:8.0
-    ports:
-      - "3306:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=rootpassword
       - MYSQL_DATABASE=fb_analyzer
@@ -104,32 +146,19 @@ services:
       - ./infrastructure/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
     networks:
       - fb-analyzer-network
+    labels:
+      - "traefik.enable=false"  # Don't expose MySQL to Traefik
 
   # Redis for Queue
   redis:
     image: redis:6.2-alpine
-    ports:
-      - "6379:6379"
     volumes:
       - redis-data:/data
       - ./infrastructure/redis/redis.conf:/usr/local/etc/redis/redis.conf
     networks:
       - fb-analyzer-network
-
-  # Nginx for routing
-  nginx:
-    image: nginx:1.21-alpine
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./infrastructure/nginx/conf.d:/etc/nginx/conf.d
-    depends_on:
-      - fb-analyzer-api-gateway
-      - fb-analyzer-frontend
-    networks:
-      - fb-analyzer-network
+    labels:
+      - "traefik.enable=false"  # Don't expose Redis to Traefik
 
 networks:
   fb-analyzer-network:


### PR DESCRIPTION
## Changes

- Replaced Nginx with Traefik as the reverse proxy
- Configured beautiful localhost URLs for each service (e.g., fb-analyzer.localhost)
- Removed direct port mappings in favor of hostname-based routing
- Updated service names to reflect the new focus on Facebook page events
- Added proper Traefik labels for service discovery
- Configured Traefik dashboard at traefik.fb-analyzer.localhost:8080

This change improves the local development experience by providing clean URLs for each service without having to remember port numbers.