### PR TITLE
Integrate API Gateway with Frontend and Add Traefik Dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     build:
       context: ./services/fb-analyzer-api-gateway
     depends_on:
+      - traefik
       - mysql
       - redis
     environment:
@@ -156,6 +157,7 @@ services:
     networks:
       - fb-analyzer-network
     depends_on:
+      - traefik
       - fb-analyzer-api-gateway
     labels:
       - "traefik.enable=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
     build:
       context: ./services/fb-analyzer-frontend
     environment:
-      - REACT_APP_API_BASE_URL=http://event-fetcher.fb-analyzer.localhost
+      - REACT_APP_API_BASE_URL=http://api.fb-analyzer.localhost/api
       - REACT_APP_FACEBOOK_API_VERSION=v18.0
       - REACT_APP_FACEBOOK_APP_ID=${FACEBOOK_APP_ID}
     volumes:
@@ -156,7 +156,7 @@ services:
     networks:
       - fb-analyzer-network
     depends_on:
-      - fb-analyzer-event-fetcher
+      - fb-analyzer-api-gateway
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=Host(`fb-analyzer.localhost`)"


### PR DESCRIPTION
This PR integrates the newly implemented API Gateway with the Frontend and adds proper dependency management for Traefik.\n\n## Changes\n\n1. **Docker Compose Updates**:\n   - Updated the frontend to use the API Gateway instead of directly connecting to the event-fetcher service\n   - Added Traefik as a dependency for both the frontend and API Gateway services\n   - Updated the dependency chain to ensure proper startup order\n\n2. **Architecture Improvements**:\n   - Centralized all API requests through the API Gateway\n   - Ensured that Traefik is available before services that depend on it start\n   - Improved the overall architecture by following best practices for service dependencies\n\nThis change ensures that the services start in the correct order and that the frontend can properly communicate with backend services through the API Gateway.