### PR TITLE
Update GitHub repository settings to only allow rebase merges

### DIFF
--- a/terraform/modules/github_repositories/main.tf
+++ b/terraform/modules/github_repositories/main.tf
@@ -12,9 +12,9 @@ resource "github_repository" "repo" {
   has_wiki          = true
   has_downloads     = true
 
-  # Merge strategies
-  allow_merge_commit = true
-  allow_squash_merge = true
+  # Merge strategies - only allow rebase merges as per requirements
+  allow_merge_commit = false
+  allow_squash_merge = false
   allow_rebase_merge = true
   allow_auto_merge   = true
   delete_branch_on_merge = true


### PR DESCRIPTION
This PR updates the GitHub repository settings in Terraform to enforce consistent PR merge settings across all repositories:\n\n- Only allow rebase merges (disable merge commits and squash merges)\n- Enable auto-merge functionality\n- Automatically delete branches after merging\n\nThese settings ensure a cleaner commit history and streamlined PR workflow.